### PR TITLE
Add Pomodoro to test matrix

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -13,7 +13,8 @@
 		"https://downloads.wordpress.org/plugin/wpforms-lite.zip",
 		"wearerequired/translations-cache",
 		"swissspidy/ginger-mo",
-		"pressjitsu/pomodoro"
+		"pressjitsu/pomodoro",
+		"soderlind/wp-cache-textdomain"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -12,7 +12,8 @@
 		"https://downloads.wordpress.org/plugin/wp-performance-pack.zip",
 		"https://downloads.wordpress.org/plugin/wpforms-lite.zip",
 		"wearerequired/translations-cache",
-		"swissspidy/ginger-mo"
+		"swissspidy/ginger-mo",
+		"pressjitsu/pomodoro"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",

--- a/tests/performance/fixtures/testUtils.ts
+++ b/tests/performance/fixtures/testUtils.ts
@@ -33,6 +33,12 @@ class TestUtils {
 			await this.requestUtils.activatePlugin( 'translations-cache' );
 		}
 
+		if ( scenario === Scenario.Transients ) {
+			await this.requestUtils.activatePlugin(
+				'a-faster-load-textdomain'
+			);
+		}
+
 		if ( scenario === Scenario.Pomodoro ) {
 			await this.requestUtils.activatePlugin(
 				'pom-odoro-translation-cache'
@@ -73,6 +79,7 @@ class TestUtils {
 		await this.requestUtils.deactivatePlugin( 'native-gettext' );
 		await this.requestUtils.deactivatePlugin( 'wp-performance-pack' );
 		await this.requestUtils.deactivatePlugin( 'translations-cache' );
+		await this.requestUtils.deactivatePlugin( 'a-faster-load-textdomain' );
 		await this.requestUtils.deactivatePlugin(
 			'pom-odoro-translation-cache'
 		);

--- a/tests/performance/fixtures/testUtils.ts
+++ b/tests/performance/fixtures/testUtils.ts
@@ -33,6 +33,12 @@ class TestUtils {
 			await this.requestUtils.activatePlugin( 'translations-cache' );
 		}
 
+		if ( scenario === Scenario.Pomodoro ) {
+			await this.requestUtils.activatePlugin(
+				'pom-odoro-translation-cache'
+			);
+		}
+
 		if (
 			scenario === Scenario.GingerMo ||
 			scenario === Scenario.GingerMoPhp ||
@@ -67,6 +73,9 @@ class TestUtils {
 		await this.requestUtils.deactivatePlugin( 'native-gettext' );
 		await this.requestUtils.deactivatePlugin( 'wp-performance-pack' );
 		await this.requestUtils.deactivatePlugin( 'translations-cache' );
+		await this.requestUtils.deactivatePlugin(
+			'pom-odoro-translation-cache'
+		);
 
 		await this.clearCaches();
 	}

--- a/tests/performance/utils/index.ts
+++ b/tests/performance/utils/index.ts
@@ -9,6 +9,7 @@ export const testCases: TestCase[] = [
 	{ locale: 'de_DE', scenario: Scenario.NativeGettext, objectCache: false },
 	{ locale: 'de_DE', scenario: Scenario.Dynamo, objectCache: false },
 	{ locale: 'de_DE', scenario: Scenario.Apcu, objectCache: false },
+	{ locale: 'de_DE', scenario: Scenario.Pomodoro, objectCache: false },
 	{ locale: 'en_US', scenario: Scenario.Default, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.Default, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.GingerMo, objectCache: true },
@@ -17,6 +18,7 @@ export const testCases: TestCase[] = [
 	{ locale: 'de_DE', scenario: Scenario.NativeGettext, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.Dynamo, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.Apcu, objectCache: true },
+	{ locale: 'de_DE', scenario: Scenario.Pomodoro, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.ObjectCache, objectCache: true },
 ];
 

--- a/tests/performance/utils/index.ts
+++ b/tests/performance/utils/index.ts
@@ -10,6 +10,7 @@ export const testCases: TestCase[] = [
 	{ locale: 'de_DE', scenario: Scenario.Dynamo, objectCache: false },
 	{ locale: 'de_DE', scenario: Scenario.Apcu, objectCache: false },
 	{ locale: 'de_DE', scenario: Scenario.Pomodoro, objectCache: false },
+	{ locale: 'de_DE', scenario: Scenario.Transients, objectCache: false },
 	{ locale: 'en_US', scenario: Scenario.Default, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.Default, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.GingerMo, objectCache: true },
@@ -19,6 +20,7 @@ export const testCases: TestCase[] = [
 	{ locale: 'de_DE', scenario: Scenario.Dynamo, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.Apcu, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.Pomodoro, objectCache: true },
+	{ locale: 'de_DE', scenario: Scenario.Transients, objectCache: true },
 	{ locale: 'de_DE', scenario: Scenario.ObjectCache, objectCache: true },
 ];
 

--- a/tests/performance/utils/types.ts
+++ b/tests/performance/utils/types.ts
@@ -8,6 +8,7 @@ export enum Scenario {
 	Apcu = 'Cache in APCu',
 	NativeGettext = 'Native Gettext',
 	Pomodoro = 'Pomodoro',
+	Transients = 'Cache in transients',
 }
 
 export type TestCase = {

--- a/tests/performance/utils/types.ts
+++ b/tests/performance/utils/types.ts
@@ -7,6 +7,7 @@ export enum Scenario {
 	ObjectCache = 'Cache in object cache',
 	Apcu = 'Cache in APCu',
 	NativeGettext = 'Native Gettext',
+	Pomodoro = 'Pomodoro',
 }
 
 export type TestCase = {


### PR DESCRIPTION
See https://make.wordpress.org/core/2023/07/24/i18n-performance-analysis/#comment-45276

Pomodoro has been tested before, but this adds a bit more transparency.

----

**Performance Test Results**

Performance test results for 93fcea1b3990a8ef79822b27a6c2c84ac69c07b0 are in 🛎️!

**WordPress Admin**

| Locale |       Scenario        | Object Cache | wp-memory-usage | wp-total  | TTFB      |
| :----- | :-------------------: | :----------: | :-------------: | :-------: | :-------- |
| en_US  |        Default        |              |    15.91 MB     | 173.56 ms | 194.35 ms |
| de_DE  |        Default        |              |    32.42 MB     | 230.44 ms | 245.10 ms |
| de_DE  |    Ginger MO (MO)     |              |    20.50 MB     | 214.47 ms | 227.00 ms |
| de_DE  |    Ginger MO (PHP)    |              |    17.51 MB     | 183.19 ms | 196.75 ms |
| de_DE  |   Ginger MO (JSON)    |              |    20.49 MB     | 211.96 ms | 223.95 ms |
| de_DE  |    Native Gettext     |              |    16.37 MB     | 181.95 ms | 194.50 ms |
| de_DE  |        DynaMo         |              |    21.00 MB     | 203.41 ms | 216.65 ms |
| de_DE  |     Cache in APCu     |              |    58.81 MB     | 231.01 ms | 245.45 ms |
| de_DE  |       Pomodoro        |              |    16.27 MB     | 183.58 ms | 196.45 ms |
| de_DE  |  Cache in transients  |              |    66.43 MB     | 268.16 ms | 280.30 ms |
| en_US  |        Default        |      ✅       |    23.70 MB     | 253.78 ms | 266.45 ms |
| de_DE  |        Default        |      ✅       |    39.97 MB     | 274.44 ms | 285.75 ms |
| de_DE  |    Ginger MO (MO)     |      ✅       |    28.04 MB     | 293.71 ms | 308.20 ms |
| de_DE  |    Ginger MO (PHP)    |      ✅       |    25.05 MB     | 213.19 ms | 226.35 ms |
| de_DE  |   Ginger MO (JSON)    |      ✅       |    28.04 MB     | 241.38 ms | 255.70 ms |
| de_DE  |    Native Gettext     |      ✅       |    23.98 MB     | 286.50 ms | 310.45 ms |
| de_DE  |        DynaMo         |      ✅       |    27.79 MB     | 325.61 ms | 348.60 ms |
| de_DE  |     Cache in APCu     |      ✅       |    66.36 MB     | 325.94 ms | 344.75 ms |
| de_DE  |       Pomodoro        |      ✅       |    23.81 MB     | 266.21 ms | 278.60 ms |
| de_DE  |  Cache in transients  |      ✅       |    66.69 MB     | 360.92 ms | 375.50 ms |
| de_DE  | Cache in object cache |      ✅       |    40.01 MB     | 241.15 ms | 255.35 ms |

**Twenty Twenty-Three**

| Locale |       Scenario        | Object Cache | wp-memory-usage | wp-total  | TTFB      |
| :----- | :-------------------: | :----------: | :-------------: | :-------: | :-------- |
| en_US  |        Default        |              |    22.69 MB     | 170.56 ms | 178.40 ms |
| de_DE  |        Default        |              |    36.09 MB     | 226.41 ms | 235.70 ms |
| de_DE  |    Ginger MO (MO)     |              |    26.11 MB     | 213.16 ms | 221.00 ms |
| de_DE  |    Ginger MO (PHP)    |              |    23.83 MB     | 189.69 ms | 197.45 ms |
| de_DE  |   Ginger MO (JSON)    |              |    26.11 MB     | 185.10 ms | 192.90 ms |
| de_DE  |    Native Gettext     |              |    22.84 MB     | 177.94 ms | 187.10 ms |
| de_DE  |        DynaMo         |              |    26.43 MB     | 204.03 ms | 212.65 ms |
| de_DE  |     Cache in APCu     |              |    57.49 MB     | 241.99 ms | 250.80 ms |
| de_DE  |       Pomodoro        |              |    22.77 MB     | 169.31 ms | 176.75 ms |
| de_DE  |  Cache in transients  |              |    57.49 MB     | 240.25 ms | 248.65 ms |
| en_US  |        Default        |      ✅       |    22.74 MB     | 191.19 ms | 198.50 ms |
| de_DE  |        Default        |      ✅       |    36.17 MB     | 266.38 ms | 274.70 ms |
| de_DE  |    Ginger MO (MO)     |      ✅       |    26.19 MB     | 252.06 ms | 259.55 ms |
| de_DE  |    Ginger MO (PHP)    |      ✅       |    23.91 MB     | 207.89 ms | 215.35 ms |
| de_DE  |   Ginger MO (JSON)    |      ✅       |    26.18 MB     | 247.94 ms | 256.25 ms |
| de_DE  |    Native Gettext     |      ✅       |    22.98 MB     | 238.54 ms | 246.50 ms |
| de_DE  |        DynaMo         |      ✅       |    25.64 MB     | 218.07 ms | 226.55 ms |
| de_DE  |     Cache in APCu     |      ✅       |    57.57 MB     | 282.45 ms | 290.50 ms |
| de_DE  |       Pomodoro        |      ✅       |    22.84 MB     | 219.57 ms | 227.25 ms |
| de_DE  |  Cache in transients  |      ✅       |    57.57 MB     | 323.30 ms | 331.80 ms |
| de_DE  | Cache in object cache |      ✅       |    36.23 MB     | 255.85 ms | 264.55 ms |

**Twenty Twenty-One**

| Locale |       Scenario        | Object Cache | wp-memory-usage | wp-total  | TTFB      |
| :----- | :-------------------: | :----------: | :-------------: | :-------: | :-------- |
| en_US  |        Default        |              |    22.29 MB     | 174.03 ms | 182.65 ms |
| de_DE  |        Default        |              |    35.76 MB     | 226.19 ms | 235.15 ms |
| de_DE  |    Ginger MO (MO)     |              |    25.73 MB     | 204.70 ms | 212.80 ms |
| de_DE  |    Ginger MO (PHP)    |              |    23.44 MB     | 184.04 ms | 192.60 ms |
| de_DE  |   Ginger MO (JSON)    |              |    25.73 MB     | 200.97 ms | 209.75 ms |
| de_DE  |    Native Gettext     |              |    22.45 MB     | 178.38 ms | 186.50 ms |
| de_DE  |        DynaMo         |              |    26.06 MB     | 197.46 ms | 206.40 ms |
| de_DE  |     Cache in APCu     |              |    57.27 MB     | 242.32 ms | 252.10 ms |
| de_DE  |       Pomodoro        |              |    22.37 MB     | 171.59 ms | 179.85 ms |
| de_DE  |  Cache in transients  |              |    57.33 MB     | 237.03 ms | 246.60 ms |
| en_US  |        Default        |      ✅       |    22.34 MB     | 182.20 ms | 189.60 ms |
| de_DE  |        Default        |      ✅       |    35.82 MB     | 215.93 ms | 222.95 ms |
| de_DE  |    Ginger MO (MO)     |      ✅       |    25.79 MB     | 215.49 ms | 222.45 ms |
| de_DE  |    Ginger MO (PHP)    |      ✅       |    23.50 MB     | 195.75 ms | 202.65 ms |
| de_DE  |   Ginger MO (JSON)    |      ✅       |    25.79 MB     | 190.85 ms | 197.90 ms |
| de_DE  |    Native Gettext     |      ✅       |    22.58 MB     | 176.14 ms | 183.05 ms |
| de_DE  |        DynaMo         |      ✅       |    25.25 MB     | 181.40 ms | 188.00 ms |
| de_DE  |     Cache in APCu     |      ✅       |    57.33 MB     | 238.37 ms | 245.65 ms |
| de_DE  |       Pomodoro        |      ✅       |    22.44 MB     | 183.90 ms | 190.65 ms |
| de_DE  |  Cache in transients  |      ✅       |    57.34 MB     | 286.11 ms | 293.55 ms |
| de_DE  | Cache in object cache |      ✅       |    35.88 MB     | 218.44 ms | 226.50 ms |


